### PR TITLE
Locale Time Format with Seconds

### DIFF
--- a/rss-feed@gnome-shell-extension.todevelopers.github.com/extension.js
+++ b/rss-feed@gnome-shell-extension.todevelopers.github.com/extension.js
@@ -282,17 +282,6 @@ const RssFeedButton = new Lang.Class({
     },
 
     /*
-     *  Lead number with zeros
-     *  num - input number
-     *  size - size of number leadign with zeros
-     */
-    _pad: function (num, size) {
-        let s = num + "";
-        while (s.length < size) s = "0" + s;
-        return s;
-    },
-
-    /*
      *  On HTTP request response download callback
      *  responseData - response data
      *  position - Position in RSS sources list
@@ -331,9 +320,7 @@ const RssFeedButton = new Lang.Class({
         this._refreshExtensionUI();
 
         // update last download time
-        let time = new Date();
-        this._lastUpdateTime.set_label(_("Last update")+': ' + this._pad(time.getHours(), 2)
-            + ':' + this._pad(time.getMinutes(), 2));
+        this._lastUpdateTime.set_label(_("Last update")+': ' + new Date().toLocaleTimeString());
 
         rssParser.clear();
     },


### PR DESCRIPTION
This makes the extension use the locale time format, but now seconds are displayed, too. According to [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString), the format **hour, minute** should be supported by any locale, but I can't find a way to specify this. The suggestions I found was to do one of these:
`toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});` (I still have the seconds displayed)
`toLocaleTimeString().replace(/:\d{2}\s/,' ');` (which would not work on any locale)
 Do you have any idea how to avoid the seconds?